### PR TITLE
Optimize UI with a single call to get the whole board

### DIFF
--- a/packages/stratego-four/docker-compose.yml
+++ b/packages/stratego-four/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     image: trufflesuite/ganache-cli
     ports:
       - 8545:8545
-      - 8546:8546
+      - 8546:8545
     command:
       - --gasPrice=0
 

--- a/packages/stratego-four/src/store/drizzleOptions.js
+++ b/packages/stratego-four/src/store/drizzleOptions.js
@@ -4,7 +4,7 @@ const mnemonic =
 
 export default {
   contracts: [require('../build/contracts/Stratego4')],
-
+  events: ['PieceMoved'],
   web3: {
     web3: {
       customProvider: pantheonProvider(mnemonic)


### PR DESCRIPTION
**Related Issue**  
Supports #4 

**Related PRs**  
This PR is not dependent on any other PR

**What does this PR do?**  
Speeds up the UI as it only needs to create one subscription instead of 80

**Description of Changes**  
Solidity read to get the whole board as an array of touples with the index representing an object.

Game UI now has one subscription to that fn rather than 80, one for each piece. 

**What gif most accurately describes how I feel towards this PR?**  

![](https://media2.giphy.com/media/Gpu3skdN58ApO/200w.gif?cid=5a38a5a25ceed746617774436b55ada4&rid=200w.gif)

